### PR TITLE
Update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 A buildpack to install gsl on a heroku dyno.
 
-This buildpack downloads a compiled version of GSL so that it can be used by other buildpacks. 
+This buildpack downloads a compiled version of GSL so that it can be used by any buildpack that comes after it in the buildpack chain. 
 
 ## Installation
+
+*Note :  heroku multi buildpack used to be required, but it's no longer the case. Now heroku supports multiple buildpacks natively.*
 
 Add the buildpack to your application ; in the buildpack chain, it should appear before any other buildpack that may require it. Hence the `--index=1` option :
 
@@ -12,7 +14,7 @@ Add the buildpack to your application ; in the buildpack chain, it should appear
 heroku buildpacks:add https://github.com/nolman/heroku-gsl-buildpack.git --index=1
 ```
 
-You can check that the buildpack chain is ok with :
+You can check that the buildpack chain is the right order with :
 
 ```
 heroku buildpacks
@@ -20,8 +22,6 @@ heroku buildpacks
 1. https://github.com/nolman/heroku-gsl-buildpack.git
 2. heroku/ruby
 ```
-
-*Note :  heroku multi buildpack used to be required, but it's no longer the case. Now heroku supports multiple buildpacks natively.*
 
 The buildpack can be used with another buildback than `heroku/ruby`, but if your aim is to make the `gsl` gem work on heroku, you can just add `gem gsl` to your Gemfile and you should now be able to deploy.
 

--- a/README.md
+++ b/README.md
@@ -2,34 +2,34 @@
 
 A buildpack to install gsl on a heroku dyno.
 
+This buildpack downloads a compiled version of GSL so that it can be used by other buildpacks. 
+
 ## Installation
 
-Use heroku multi buildpack:
-
-https://github.com/nolman/heroku-buildpack-multi
-
-Note: you need a variant of the buildpack multi that allows you to chain exported variables from one buildpack to the next. For now my fork will work fine (using ./export from the buildpack), in the longer term there should be a standard way to chain buildpacks together.
-
-To set this buildpack on heroku run the following:
+Add the buildpack to your application ; in the buildpack chain, it should appear before any other buildpack that may require it. Hence the `--index=1` option :
 
 ```
-heroku config:set BUILDPACK_URL="https://github.com/nolman/heroku-buildpack-multi"
+heroku buildpacks:add https://github.com/nolman/heroku-gsl-buildpack.git --index=1
 ```
 
-Then add a .buildpacks file to your app:
+You can check that the buildpack chain is ok with :
 
 ```
-https://github.com/nolman/heroku-gsl-buildpack.git
-https://github.com/heroku/heroku-buildpack-ruby.git#v119
+heroku buildpacks
+
+1. https://github.com/nolman/heroku-gsl-buildpack.git
+2. heroku/ruby
 ```
 
-You can replace the ruby buildpack with whatever you language of choice is.
+*Note :  heroku multi buildpack used to be required, but it's no longer the case. Now heroku supports multiple buildpacks natively.*
+
+The buildpack can be used with another buildback than `heroku/ruby`, but if your aim is to make the `gsl` gem work on heroku, you can just add `gem gsl` to your Gemfile and you should now be able to deploy.
 
 ## Compiling binaries on heroku
 
-You can find an example script that compiles binary from a source tar.gz [here](extra/build_binary)
+If you want to recompile a more recent/different version of gsl, you can find an example script that compiles binary from a source tar.gz [here](extra/build_binary)
 
-This script relies on the fog gem to upload the binary to s3. You will need to add that dependency to your Gemfile. You will also need to set an ENV var for your AWS key and secret.
+This script relies on the fog gem to upload the binary, once compiled, to s3. You will need to add that dependency to your Gemfile. You will also need to set an ENV var for your AWS key and secret.
 
 ## Known issues
 


### PR DESCRIPTION
Hi Norman, this is a PR to update the README as you've suggested yesterday :-) 

There are significant changes in the installation method, since heroku now supports multiple buildpacks natively. So I think this is now the preferred method.

I have tried to clarify a bit what the buildpack does, and what's the use of the build script.

You can check the result on [my fork](https://github.com/BenTalagan/heroku-gsl-buildpack), probably more readable than the diff.
